### PR TITLE
Add Date header to email

### DIFF
--- a/src/hunter.py
+++ b/src/hunter.py
@@ -4,6 +4,7 @@ import smtplib
 import sys
 
 from email.message import EmailMessage
+from email.utils import formatdate
 from scraper import Scraper
 
 
@@ -17,6 +18,7 @@ class Alerter:
 
     def __call__(self, subject, content):
         msg = EmailMessage()
+        msg.add_header('Date', formatdate())
         msg.set_content(content)
         if subject:
             msg['Subject'] = subject


### PR DESCRIPTION
Fix missing header when using IMAP+Amavis self-hosted mail server.

```
The message WAS NOT relayed to: [...]
INVALID HEADER
Missing required header field: "Date"
```