### PR TITLE
Changing slack alert to markdown formatted

### DIFF
--- a/src/alerter.py
+++ b/src/alerter.py
@@ -46,7 +46,7 @@ class SlackAlerter(AlerterBase):
                 {
                     "type": "section",
                     "text": {
-                        "type": "plain_text",
+                        "type": "mrkdwn",
                         "text": kwargs.get("content")
                     }
                 }


### PR DESCRIPTION
Changing the text type to mrkdwn so that the links sent from the alert are clickable in the slack message.