### PR TITLE
Add Telegram alert type

### DIFF
--- a/src/alerter.py
+++ b/src/alerter.py
@@ -97,6 +97,33 @@ class DiscordAlerter(AlerterBase):
                 f"Issue with sending webhook to discord. {traceback.format_exc()}"
             )
 
+class TelegramAlerter(AlerterBase):
+    def __init__(self, args):
+        self._webhook_url = args.webhook_url
+        self._chat_id = args.chat_id
+        super().__init__(args)
+
+    def _notification_function(self, **kwargs):
+        _telegram_webhook_generated = {
+            "chat_id": self._chat_id,
+            "parse_mode": "html",
+            "text": f'<b>{kwargs.get("subject")}</b>\n{kwargs.get("content")}'
+        }
+        try:
+            logging.debug(f"Telegram Webhook URL: {self._webhook_url}")
+            send_request = requests.post(
+                self._webhook_url,
+                json=_telegram_webhook_generated,
+            )
+            if send_request.status_code != 200:
+                logging.error(
+                    f"There was an issue sending to Telegram due to an invalid request: {send_request.status_code} -> {send_request.text}"
+                )
+        except Exception:
+            logging.error(
+                f"Issue with sending webhook to Telegram. {traceback.format_exc()}"
+            )
+
 
 class EmailAlerter(AlerterBase):
     def __init__(self, args):

--- a/src/hunter.py
+++ b/src/hunter.py
@@ -2,7 +2,7 @@ import logging
 import sched
 import sys
 
-from alerter import EmailAlerter, DiscordAlerter, SlackAlerter
+from alerter import EmailAlerter, DiscordAlerter, SlackAlerter, TelegramAlerter
 
 
 class Engine:
@@ -11,7 +11,8 @@ class Engine:
         alert_types = {
             "email": EmailAlerter,
             "discord": DiscordAlerter,
-            "slack": SlackAlerter
+            "slack": SlackAlerter,
+            "telegram": TelegramAlerter
         }
         self.alerter = alert_types[args.alerter_type](args)
         logging.debug(f"selected alerter: {args.alerter_type} -> {self.alerter}")

--- a/src/run.py
+++ b/src/run.py
@@ -30,6 +30,7 @@ def parse_args():
 
     # discord (or any other webhook based alerter) - related arguments
     parser.add_argument("-w", "--webhook", help="A valid HTTP url for a POST request.", dest="webhook_url")
+    parser.add_argument("-i", "--chat-id", help="Telegram ID number for the chat room", dest="chat_id")
     return parser.parse_args()
 
 


### PR DESCRIPTION
This adds the ability to use Telegram as an alert type.  It requires the addition of the chat_id parameter in addition to the webhook URL.