### PR TITLE
automatically remove container upon stopping it

### DIFF
--- a/docker_run.bash
+++ b/docker_run.bash
@@ -66,7 +66,7 @@ fi
 
 container_name=$(basename $config .yaml)
 
-docker_run_cmd="docker run -d -rm --name $container_name --network host -v $config:/config.yaml $image --alerter $alerter"
+docker_run_cmd="docker run -d --rm --name $container_name --network host -v $config:/config.yaml $image --alerter $alerter"
 
 if [ "$alerter" = "email" ]; then
     docker_run_cmd="$docker_run_cmd --email ${emails[@]} --relay $relay"

--- a/docker_run.bash
+++ b/docker_run.bash
@@ -66,7 +66,7 @@ fi
 
 container_name=$(basename $config .yaml)
 
-docker_run_cmd="docker run -d --name $container_name --network host -v $config:/config.yaml $image --alerter $alerter"
+docker_run_cmd="docker run -d -rm --name $container_name --network host -v $config:/config.yaml $image --alerter $alerter"
 
 if [ "$alerter" = "email" ]; then
     docker_run_cmd="$docker_run_cmd --email ${emails[@]} --relay $relay"


### PR DESCRIPTION
The workflow for launching an updated code calls for two steps, stopping and then removing the container. By adding the `--rm` flag to the `docker run` command the container gets removed automatically hence turning this to a one step operation.