### PR TITLE
added vagrant configuration for light weight vm option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 .idea/
 __pycache__
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+Vagrant.configure("2") do |config|
+  config.vm.define :hunter do |hunter|
+    hunter.vm.box = "bento/ubuntu-18.04"
+    hunter.vm.network "forwarded_port", guest: 80, host: 9091, host_ip: "127.0.0.1"
+
+    hunter.ssh.forward_agent = true
+
+    hunter.vm.network "private_network", type: "dhcp", virtualbox__intnet: true
+
+    hunter.vm.synced_folder ".", "/home/vagrant/inventoryhunter"
+
+    hunter.vm.provider "virtualbox" do |v|
+      v.gui = false
+      v.memory = "2048"
+      v.cpus = 2
+    end
+
+    hunter.vm.provision "shell", path: "linux-ubuntu-setup.sh", args: "vagrant"
+  end
+end

--- a/linux-ubuntu-setup.sh
+++ b/linux-ubuntu-setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -z $1 ]
+then
+    RUN_BY=`who | awk '{print $1}'`
+else
+    RUN_BY=$1
+fi
+RUN_BY_HOME=`/bin/bash -c "echo ~$RUN_BY"`
+echo "Run by $RUN_BY with home $RUN_BY_HOME"
+
+apt-get update
+apt-get install -y software-properties-common
+
+# Install Docker
+apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io
+usermod -G docker $RUN_BY
+sed -i -e 's/\r$//' docker_run.bash


### PR DESCRIPTION
Hello There :)

I created a light weight ubuntu vm option for those who don't want to go through the Hassel of docker desktop on windows or mac

all the user needs is [virtualbox](https://www.virtualbox.org/wiki/Downloads) and [vagrant](https://www.vagrantup.com/)

all the user have to do is to cd into the project's folder, after installing those 2 software, and run vagrant up, it will setup the entire vm with all the tools he need (which is only docker)

then he can cd into inventoryhunter which is synced with the main folder on desktop and run the commands in your readme and that's basically it.

I hope that helps some people.