### PR TITLE
Add SMTP relay authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ If you are interested in configuring multiple alerters or would like to keep you
           - myemail@email.com
           - myfriendsemail@email.com
         relay: 127.0.0.1
+        password: XXXXXXXXXX   # optional
     ...
     ```
 

--- a/src/alerter/emailer.py
+++ b/src/alerter/emailer.py
@@ -14,6 +14,7 @@ class EmailAlerter(Alerter):
         self.sender = kwargs.get('sender')
         self.recipients = kwargs.get('recipients')
         self.relay = kwargs.get('relay')
+        self.password = kwargs.get('password', None)
 
     @classmethod
     def from_args(cls, args):
@@ -27,7 +28,8 @@ class EmailAlerter(Alerter):
         sender = config['sender']
         recipients = config['recipients']
         relay = config['relay']
-        return cls(sender=sender, recipients=recipients, relay=relay)
+        password = config.get('password', None)
+        return cls(sender=sender, recipients=recipients, relay=relay, password=password)
 
     @staticmethod
     def get_alerter_type():
@@ -47,4 +49,6 @@ class EmailAlerter(Alerter):
         msg["To"] = ", ".join(self.recipients)
         with smtplib.SMTP(self.relay) as s:
             logging.debug(f"sending email: subject: {set_subject}")
+            if self.password:
+                s.login(self.sender, self.password)
             s.send_message(msg)


### PR DESCRIPTION
Allow optional password authentication to an SMTP relay with the password specified in the `alerters.yaml` config file. Username is the sender email.