### PR TITLE
Allow alternative Selenium Chrome driver install paths

### DIFF
--- a/src/driver.py
+++ b/src/driver.py
@@ -27,9 +27,18 @@ class Driver(ABC):
 class SeleniumDriver(Driver):
     def __init__(self, timeout):
         super().__init__(timeout)
-        self.driver_path = '/usr/bin/chromedriver'
-        if not os.path.exists(self.driver_path):
-            raise Exception(f'not found: {self.driver_path}')
+        driver_paths = [
+            '/usr/bin/chromedriver',
+            '/usr/bin/local/chromedriver',
+        ]
+        self.driver_path = None
+        for driver_path in driver_paths:
+            if os.path.exists(driver_path):
+                self.driver_path = driver_path
+                break
+
+        if not self.driver_path:
+            raise Exception('Selenium Chrome driver not found at ' + ' or '.join(driver_paths))
 
         self.options = webdriver.ChromeOptions()
         self.options.headless = True


### PR DESCRIPTION
Check for the Selenium Chrome driver in locations other than `/usr/bin/chromedriver`. Useful for running on different systems; e.g. FreeBSD installs to `/usr/bin/local/chromedriver` by default.